### PR TITLE
Fixes an XCode static analyzer warning.

### DIFF
--- a/imath.c
+++ b/imath.c
@@ -2133,7 +2133,6 @@ mp_result mp_int_read_unsigned(mp_int z, unsigned char *buf, int len)
 {
   mp_size need, i;
   unsigned char *tmp;
-  mp_digit *dz;
 
   CHECK(z != NULL && buf != NULL && len > 0);
 
@@ -2144,10 +2143,9 @@ mp_result mp_int_read_unsigned(mp_int z, unsigned char *buf, int len)
 
   mp_int_zero(z);
 
-  dz = MP_DIGITS(z);
   for (tmp = buf, i = len; i > 0; --i, ++tmp) {
     (void) s_qmul(z, CHAR_BIT);
-    *dz |= *tmp;
+    *MP_DIGITS(z) |= *tmp;
   }
 
   return MP_OK;


### PR DESCRIPTION
It seems that there could be a situation where the digits part of the z struct is being reallocated and thus the dz pointer is pointing into deallocated memory.

By extracting the digits pointer after the s_qmul call this is prevented. In our project's set of unit tests the functionality is does not break.
