### PR TITLE
IMath portability fixes from PostgreSQL

### DIFF
--- a/imath.c
+++ b/imath.c
@@ -2511,7 +2511,7 @@ STATIC void     s_qmod(mp_int z, mp_size p2)
 {
   mp_size start = p2 / MP_DIGIT_BIT + 1, rest = p2 % MP_DIGIT_BIT;
   mp_size uz = MP_USED(z);
-  mp_digit mask = (1 << rest) - 1;
+  mp_digit mask = ((mp_digit) 1 << rest) - 1;
 
   if (start <= uz) {
     MP_USED(z) = start;
@@ -2586,7 +2586,7 @@ STATIC int      s_qmul(mp_int z, mp_size p2)
  */
 STATIC int       s_qsub(mp_int z, mp_size p2)
 {
-  mp_digit hi = (1 << (p2 % MP_DIGIT_BIT)), *zp;
+  mp_digit hi = ((mp_digit) 1 << (p2 % MP_DIGIT_BIT)), *zp;
   mp_size  tdig = (p2 / MP_DIGIT_BIT), pos;
   mp_word  w = 0;
 
@@ -2668,7 +2668,7 @@ STATIC int       s_2expt(mp_int z, mp_small k)
 
   dz = MP_DIGITS(z);
   ZERO(dz, ndig);
-  *(dz + ndig - 1) = (1 << rest);
+  *(dz + ndig - 1) = ((mp_digit) 1 << rest);
   MP_USED(z) = ndig;
 
   return 1;
@@ -2679,7 +2679,7 @@ STATIC int      s_norm(mp_int a, mp_int b)
   mp_digit d = b->digits[MP_USED(b) - 1];
   int k = 0;
 
-  while (d < (mp_digit) (1 << (MP_DIGIT_BIT - 1))) { /* d < (MP_RADIX / 2) */
+  while (d < ((mp_digit) 1 << (MP_DIGIT_BIT - 1))) { /* d < (MP_RADIX / 2) */
     d <<= 1;
     ++k;
   }

--- a/imath.c
+++ b/imath.c
@@ -2586,7 +2586,7 @@ STATIC int      s_qmul(mp_int z, mp_size p2)
  */
 STATIC int       s_qsub(mp_int z, mp_size p2)
 {
-  mp_digit hi = ((mp_digit) 1 << (p2 % MP_DIGIT_BIT)), *zp;
+  mp_digit hi = (1u << (p2 % MP_DIGIT_BIT)), *zp;
   mp_size  tdig = (p2 / MP_DIGIT_BIT), pos;
   mp_word  w = 0;
 
@@ -2668,7 +2668,7 @@ STATIC int       s_2expt(mp_int z, mp_small k)
 
   dz = MP_DIGITS(z);
   ZERO(dz, ndig);
-  *(dz + ndig - 1) = ((mp_digit) 1 << rest);
+  *(dz + ndig - 1) = (1u << rest);
   MP_USED(z) = ndig;
 
   return 1;

--- a/imath.c
+++ b/imath.c
@@ -1759,7 +1759,7 @@ mp_result mp_int_read_cstring(mp_int z, mp_size radix, const char *str, char **e
     return MP_RANGE;
 
   /* Skip leading whitespace */
-  while (isspace((int)*str))
+  while (isspace((unsigned char) *str))
     ++str;
 
   /* Handle leading sign tag (+/-, positive default) */
@@ -3139,10 +3139,16 @@ STATIC int       s_ch2val(char c, int r)
 {
   int out;
 
+  /*
+   * In some locales, isalpha() accepts characters outside the range A-Z,
+   * producing out<0 or out>=36.  The "out >= r" check will always catch
+   * out>=36.  Though nothing explicitly catches out<0, our caller reacts the
+   * same way to every negative return value.
+   */
   if (isdigit((unsigned char) c))
     out = c - '0';
   else if (r > 10 && isalpha((unsigned char) c))
-    out = toupper(c) - 'A' + 10;
+    out = toupper((unsigned char) c) - 'A' + 10;
   else
     return -1;
 
@@ -3159,7 +3165,7 @@ STATIC char      s_val2ch(int v, int caps)
     char out = (v - 10) + 'a';
 
     if (caps)
-      return toupper(out);
+      return toupper((unsigned char) out);
     else
       return out;
   }


### PR DESCRIPTION
The PostgreSQL project carries an old copy of IMath, and I am looking to
merge in your latest version.  Some local modifications we've been
carrying belong upstream.  We arrived at these in the course of fixing
compiler warnings, not live bugs.  "Sun WorkShop 6 update 2 C 5.3"
complained about the "1 << 31" integer overflow.  I don't recall which
configuration(s) complain about passing a value of type "char" to a
ctype.h function, though I have seen it recently.

Thanks,
nm
