### PR TITLE
Fix undefined behaviour in case v==SMALL_MIN

### DIFF
--- a/imath.c
+++ b/imath.c
@@ -2092,7 +2092,7 @@ STATIC int      s_ucmp(mp_int a, mp_int b)
 
 STATIC int      s_vcmp(mp_int a, mp_small v)
 {
-  mp_usmall uv = (mp_usmall) (v < 0) ? -v : v;
+  mp_usmall uv = (v < 0) ? -(mp_usmall) v : (mp_usmall) v;
   return s_uvcmp(a, uv);
 }
 


### PR DESCRIPTION
Negating a signed integer is undefined behaviour if it has the minimum value (as it cannot be represented in the integer of the that bit-size). Solution: Use unsigned negation.

See http://stackoverflow.com/questions/17313579/is-there-a-safe-way-to-get-the-unsigned-absolute-value-of-a-signed-integer-with