### PR TITLE
Fix undefined signed operations

### DIFF
--- a/imath.c
+++ b/imath.c
@@ -2511,7 +2511,7 @@ STATIC void     s_qmod(mp_int z, mp_size p2)
 {
   mp_size start = p2 / MP_DIGIT_BIT + 1, rest = p2 % MP_DIGIT_BIT;
   mp_size uz = MP_USED(z);
-  mp_digit mask = (1 << rest) - 1;
+  mp_digit mask = (1u << rest) - 1;
 
   if (start <= uz) {
     MP_USED(z) = start;
@@ -2679,7 +2679,7 @@ STATIC int      s_norm(mp_int a, mp_int b)
   mp_digit d = b->digits[MP_USED(b) - 1];
   int k = 0;
 
-  while (d < (mp_digit) (1 << (MP_DIGIT_BIT - 1))) { /* d < (MP_RADIX / 2) */
+  while (1u << (mp_digit)(MP_DIGIT_BIT - 1))) { /* d < (MP_RADIX / 2) */
     d <<= 1;
     ++k;
   }

--- a/imath.c
+++ b/imath.c
@@ -1635,7 +1635,7 @@ mp_result mp_int_to_int(mp_int z, mp_small *out)
   }
 
   if (out)
-    *out = (sz == MP_NEG) ? -(mp_small)uv : (mp_small)uv;
+    *out = (mp_small)((sz == MP_NEG) ? -uv : uv);
 
   return MP_OK;
 }


### PR DESCRIPTION
Some operations are defined only unsigned integers because they mess with the signed bit.

Found using undefined behavior sanitizer on Polly.

Reported by Matthias Krüger <matthias.krueger@famsik.de>
https://bugs.llvm.org/show_bug.cgi?id=33197