### PR TITLE
Add a Travis CI configuration for imath.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+# Build and test configuration for travis-ci.com.
+
+language: c
+script: make clean check
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode10.1
+      compiler: clang
+    - os: linux
+      compiler: clang
+    - os: linux
+      compiler: gcc
+

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ## 
 ## Name:     test.sh
 ## Purpose:  Run test suites for IMath library.


### PR DESCRIPTION
Updates #27. A very simple test plan that simply runs "make check" for each
interesting configuration. Right now the "interesting" configurations are macOS
(because I use it) and Linux (because everyone uses it), and the latter with
both Clang and GCC.

I had to update test.sh to be explicitly Bash rather than Bourne, since on
macOS "sh" is an alias for Bash but not so in Ubuntu.