### PR TITLE
Ensure the Makefile respects a $CC set in the environment.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,9 @@
 
 ## Generic settings for systems with GCC (default)
 ## To build with debugging, add DEBUG=Y on the "make" command line.
+ifeq ($(origin CC),default)
 CC=gcc
+endif
 CFLAGS+=-pedantic -Wall -Werror -Wextra -Wno-unused-parameter \
 	-I. -std=c99 $(DFLAGS$(DEBUG))
 CSFLAGS=$(CFLAGS) -fPIC


### PR DESCRIPTION
As previously written, the Makefile would ignore the default and hard-select GCC.