### PR TITLE
Add "bash" to the list of packages installed for Linux in Docker.

### DIFF
--- a/tests/linux/Dockerfile
+++ b/tests/linux/Dockerfile
@@ -6,7 +6,7 @@
 #
 FROM alpine:latest AS base
 
-RUN apk add --no-cache build-base gcc gmp-dev make python2
+RUN apk add --no-cache bash build-base gcc gmp-dev make python2
 
 FROM base AS test
 VOLUME  /imath


### PR DESCRIPTION
Alpine does not include bash by default, so we need to add it explicitly to
ensure the tests will work.