### PR TITLE
Copy files into the build container.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,8 @@ gmp-compat-test: libimath.so
 docker-test:
 	if which docker ; \
 	then \
-		docker run --rm -it -v $(PWD):/imath \
-		"$(shell docker build -q tests/linux)" ; \
+		docker run --rm -it \
+		"$(shell docker build -f tests/linux/Dockerfile -q .)" ; \
 	fi
 
 $(EXAMPLES):%: imath.o imrat.o iprime.o %.o

--- a/tests/linux/Dockerfile
+++ b/tests/linux/Dockerfile
@@ -9,6 +9,6 @@ FROM alpine:latest AS base
 RUN apk add --no-cache bash build-base gcc gmp-dev make python2
 
 FROM base AS test
-VOLUME  /imath
+COPY . /imath
 WORKDIR /imath
 CMD make distclean examples check


### PR DESCRIPTION
Instead of mapping over the local filesystem, copy the build context into the
container and run the build there. The local state can still pollute the build
image, but make clean should take care of that, and this way we don't wind up
with .o files from the wrong architecture.