### PR TITLE
Fix typos in imath

### DIFF
--- a/imath.c
+++ b/imath.c
@@ -560,7 +560,7 @@ mp_result mp_int_add(mp_int a, mp_int b, mp_int c) {
 
   } else {
     /* Different signs -- subtract magnitudes, preserve sign of greater */
-    int cmp = s_ucmp(a, b); /* magnitude comparision, sign ignored */
+    int cmp = s_ucmp(a, b); /* magnitude comparison, sign ignored */
 
     /* Set x to max(a, b), y to min(a, b) to simplify later code.
        A special case yields zero for equal magnitudes.
@@ -2603,7 +2603,7 @@ static mp_result s_udiv_knuth(mp_int u, mp_int v) {
        decrease qhat by one and try again. We may need to decrease qhat one
        more time before we get a value that is smaller than r.
 
-       This way is less efficent than Knuth becuase we do more multiplies, but
+       This way is less efficent than Knuth because we do more multiplies, but
        we do not need to worry about underflow this way.
      */
     /* t = qhat * v */

--- a/imath.h
+++ b/imath.h
@@ -94,7 +94,7 @@ extern const mp_result MP_MINERR;
 void mp_int_default_precision(mp_size ndigits);
 
 /** Sets the number of digits below which multiplication will use the standard
-    quadratic "schoolbook" multiplcation algorithm rather than Karatsuba-Ofman.
+    quadratic "schoolbook" multiplication algorithm rather than Karatsuba-Ofman.
     Requires `ndigits >= sizeof(mp_word)`. */
 void mp_int_multiply_threshold(mp_size ndigits);
 


### PR DESCRIPTION
Please consider fixing the typos, that I've found while spellchecking the PostgreSQL source code.
(See https://www.postgresql.org/message-id/CAA4eK1JhUy_ThWzH9gSXhuAo4%3Dk8xJddsMLpPayrFeV-oQNH7A%40mail.gmail.com)
