### PR TITLE
Dynamically allocate the output buffer in the pi example

### DIFF
--- a/examples/pi.c
+++ b/examples/pi.c
@@ -39,8 +39,6 @@ int g_radix = 10; /* use this radix for output */
 mp_result arctan(mp_small radix, mp_small mul, mp_small x, mp_small prec,
                  mp_int sum);
 
-char g_buf[4096];
-
 int main(int argc, char *argv[]) {
   mp_result res;
   mpz_t sum1, sum2;
@@ -98,11 +96,21 @@ int main(int argc, char *argv[]) {
   }
   end = clock();
 
-  mp_int_to_string(&sum1, g_radix, g_buf, sizeof(g_buf));
+  size_t g_buf_size = ndigits + 2; /* "3" prefix and terminating '\0' */
+  char *g_buf = malloc(g_buf_size);
+  if (!g_buf) {
+    fprintf(stderr, "%s: cannot allocate memory\n", argv[0]);
+    out = 1;
+    goto CLEANUP;
+  }
+
+  mp_int_to_string(&sum1, g_radix, g_buf, g_buf_size);
   printf("%c.%s\n", g_buf[0], g_buf + 1);
 
   fprintf(stderr, "Computation took %.2f sec.\n",
           (double)(end - start) / CLOCKS_PER_SEC);
+
+  free(g_buf);
 
 CLEANUP:
   mp_int_clear(&sum1);


### PR DESCRIPTION
It's not a very valuable contribution but I was a bit afraid
yesterday when I discovered that the pi example yielded wrong
results when the number of digits was higher than 4095.

In practice there was no buffer overflow. Everything is fine.

Fixes #40.