### PR TITLE
findthreshold.py: `print` --> `print()`

### DIFF
--- a/tools/findthreshold.py
+++ b/tools/findthreshold.py
@@ -90,6 +90,6 @@ if __name__ == "__main__":
         print("%d\t%d\t%.3f\t%.3f\t%.4f" %
               (prec, thresh, trec, tnorm, tnorm / trec))
 
-    print
+    print()
 
 # Here there be dragons


### PR DESCRIPTION
```diff
-    print
+    print()
```
Current: evaluates but does nothing.
Proposed: prints a blank line.

% `python3.13`
```
Python 3.13.1 (main, Dec  3 2024, 17:59:52) [Clang 16.0.0 (clang-1600.0.26.4)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> print
<built-in function print>
>>> print()

>>>
```