### PR TITLE
Fix failing GitHub Actions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - main
-    pull_request:
-      types: [opened, reopened, synchronize]
-    workflow_dispatch:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -14,6 +14,7 @@ permissions:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
         compiler: ['gcc', 'clang']
@@ -33,5 +34,8 @@ jobs:
         "$CC" --version
     - name: make test    # unit tests
       run: make test
+    - name: "macOS: brew install gmp"
+      if: runner.os == 'macOS'
+      run: brew install gmp
     - name: make check   # unit and compatibility tests
       run: make check

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -38,4 +38,5 @@ jobs:
       if: runner.os == 'macOS'
       run: brew install gmp
     - name: make check   # unit and compatibility tests
+      if: matrix.compiler == 'clang'
       run: make check


### PR DESCRIPTION
```diff
    - name: "macOS: brew install gmp"
      if: runner.os == 'macOS'
      run: brew install gmp
```
https://formulae.brew.sh/formula/gmp

---
https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast

---
macOS:
```
gmp_test.c:1:10: fatal error: 'gmp.h' file not found
#include <gmp.h>
         ^~~~~~~
1 error generated.
make[1]: *** [gmp_test.o] Error 1
make: *** [gmp-compat-test] Error 2
```