### PR TITLE
GitHub Actions: Add ARM processors to the testing

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -39,4 +39,5 @@ jobs:
     # locally or in github actions. They work fine from the CLI, but
     # for now turn them off in CI.
     - name: make check   # unit and compatibility tests
+      if: matrix.compiler != 'gcc'  # `make check` is failing on gcc
       run: make check

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -38,7 +38,6 @@ jobs:
     # on gcc no longer work correctly when run in containers either
     # locally or in github actions. They work fine from the CLI, but
     # for now turn them off in CI.
-    #
     - name: make check   # unit and compatibility tests
       if: matrix.compiler == 'clang'
       run: make check

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -39,5 +39,4 @@ jobs:
     # locally or in github actions. They work fine from the CLI, but
     # for now turn them off in CI.
     - name: make check   # unit and compatibility tests
-      if: matrix.compiler == 'clang'
       run: make check

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,9 +4,9 @@ on:
   push:
     branches:
       - main
-    pull_request:
-      types: [opened, reopened, synchronize]
-    workflow_dispatch:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,8 +14,9 @@ permissions:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm]
         compiler: ['gcc', 'clang']
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
[Standard GitHub-hosted runners for public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) --> `ubuntu-24.04-arm`