### PR TITLE
Lint Python code with ruff

### DIFF
--- a/tests/gmp-compat-test/genctest.py
+++ b/tests/gmp-compat-test/genctest.py
@@ -1,14 +1,8 @@
 #!/usr/bin/env python3
 import sys
+
 import gmpapi
-from gmpapi import void
-from gmpapi import ilong
-from gmpapi import iint
-from gmpapi import ulong
-from gmpapi import mpz_t
-from gmpapi import size_t
-from gmpapi import charp
-from gmpapi import mpq_t
+from gmpapi import charp, iint, ilong, mpq_t, mpz_t, size_t, ulong, void
 
 
 class APITest(object):

--- a/tests/gmp-compat-test/gendata.py
+++ b/tests/gmp-compat-test/gendata.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import random
+
 import gmpapi
 
 MAX_SLONG = "9223372036854775807"

--- a/tests/gmp-compat-test/genpytest.py
+++ b/tests/gmp-compat-test/genpytest.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
-import gmpapi
 import sys
+
+import gmpapi
 
 
 def print_header(outf):

--- a/tests/gmp-compat-test/gmpapi.py
+++ b/tests/gmp-compat-test/gmpapi.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import sys
 
 
 class CType:

--- a/tests/gmp-compat-test/runtest.py
+++ b/tests/gmp-compat-test/runtest.py
@@ -3,23 +3,11 @@
 from __future__ import print_function
 
 import ctypes
-import random
+from optparse import OptionParser
+
 import gmpapi
 import wrappers
-import glob
-import sys
-import os
-from optparse import OptionParser
-from gmpapi import void
-from gmpapi import ilong
-from gmpapi import ulong
-from gmpapi import mpz_t
-from gmpapi import voidp
-from gmpapi import size_t
-from gmpapi import size_tp
-from gmpapi import iint
-from gmpapi import charp
-from gmpapi import mpq_t
+from gmpapi import charp, iint, ilong, mpq_t, mpz_t, size_t, size_tp, ulong, voidp
 
 
 def print_failure(line, test):

--- a/tools/findthreshold.py
+++ b/tools/findthreshold.py
@@ -21,7 +21,9 @@
 ## call mp_int_multiply_threshold(n) during program initialization, to
 ## establish a satisfactory result.
 ##
-import math, os, random, sys, time
+import os
+import sys
+import time
 
 
 def get_timing_stats(num_tests, precision, threshold, seed=None):

--- a/tools/mkdoc.py
+++ b/tools/mkdoc.py
@@ -9,7 +9,9 @@
 ##
 from __future__ import print_function
 
-import collections, re, sys
+import collections
+import re
+import sys
 
 # A regular expression to match commented declarations.
 # This is specific to C and not very general; it should work fine for the imath
@@ -51,8 +53,10 @@ def typeset(text):
     if fence:
         lines.append('```')
     for i, line in enumerate(lines):
-        if i == 0: lines[i] = ' -  ' + line
-        elif line: lines[i] = '    ' + line
+        if i == 0:
+            lines[i] = ' -  ' + line
+        elif line:
+            lines[i] = '    ' + line
     return '\n'.join(lines)
 
 


### PR DESCRIPTION
% `ruff check --output-format=concise ` # https://docs.astral.sh/ruff/linter
```
tests/gmp-compat-test/gmpapi.py:3:8: F401 [*] `sys` imported but unused
tests/gmp-compat-test/runtest.py:6:8: F401 [*] `random` imported but unused
tests/gmp-compat-test/runtest.py:9:8: F401 [*] `glob` imported but unused
tests/gmp-compat-test/runtest.py:10:8: F401 [*] `sys` imported but unused
tests/gmp-compat-test/runtest.py:11:8: F401 [*] `os` imported but unused
tests/gmp-compat-test/runtest.py:13:20: F401 [*] `gmpapi.void` imported but unused
tools/findthreshold.py:24:1: E401 [*] Multiple imports on one line
tools/findthreshold.py:24:8: F401 [*] `math` imported but unused
tools/findthreshold.py:24:18: F401 [*] `random` imported but unused
tools/mkdoc.py:12:1: E401 [*] Multiple imports on one line
tools/mkdoc.py:54:18: E701 Multiple statements on one line (colon)
tools/mkdoc.py:55:18: E701 Multiple statements on one line (colon)
Found 12 errors.
[*] 10 fixable with the `--fix` option.
```
Sort the imports with:
% `ruff check --select=I --fix`
```
Found 6 errors (6 fixed, 0 remaining).
```
Fix the F401 issues with:
% `ruff check --fix`
```
Found 10 errors (8 fixed, 2 remaining).
```
Manual fix up of two E701 issues.

% [`ruff rule E401`](https://docs.astral.sh/ruff/rules/multiple-imports-on-one-line)
# multiple-imports-on-one-line (E401)

Derived from the **pycodestyle** linter.

Fix is sometimes available.

## What it does
Check for multiple imports on one line.

## Why is this bad?
According to [PEP 8], "imports should usually be on separate lines."

## Example
```python
import sys, os
```

Use instead:
```python
import os
import sys
```

[PEP 8]: https://peps.python.org/pep-0008/#imports
