### PR TITLE
GitHub Action to run codespell

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,6 +12,11 @@ permissions:
   contents: read
 
 jobs:
+  codespell:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: codespell-project/actions-codespell@v2
   build:
     strategy:
       fail-fast: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.codespell]
+ignore-words-list = "inout,numer,passt,statics"


### PR DESCRIPTION
These GitHub Action tests would only pass AFTER #63 and #64 (or similar) are merged.
* #63 
* #64