### PR TITLE
Silence unused-value warnings

### DIFF
--- a/gmp_compat.c
+++ b/gmp_compat.c
@@ -39,7 +39,7 @@ typedef SSIZE_T ssize_t;
 #endif
 
 #ifdef NDEBUG
-#define CHECK(res) (res)
+#define CHECK(res) ((void)(res))
 #else
 #define CHECK(res) assert(((res) == MP_OK) && "expected MP_OK")
 #endif


### PR DESCRIPTION
The `CHECK` macro expands to a bare expression in `NDEBUG` builds, which triggers `-Wunused-value` warnings under the default warning settings in Clang and GCC.
