### PR TITLE
Use mp_size for length and counter results instead of mp_result

### DIFF
--- a/doc.md
+++ b/doc.md
@@ -513,7 +513,7 @@ mp_result <a href="imath.h#L327">mp_int_to_string</a>(mp_int z, mp_size radix, c
 
 ------------
 <a id="mp_int_string_len"></a><pre>
-mp_result <a href="imath.h#L332">mp_int_string_len</a>(mp_int z, mp_size radix);
+mp_size <a href="imath.h#L332">mp_int_string_len</a>(mp_int z, mp_size radix);
 </pre>
  -  Reports the minimum number of characters required to represent `z` as a
     zero-terminated string in the given `radix`.
@@ -560,7 +560,7 @@ mp_result <a href="imath.h#L365">mp_int_read_cstring</a>(mp_int z, mp_size radix
 
 ------------
 <a id="mp_int_count_bits"></a><pre>
-mp_result <a href="imath.h#L368">mp_int_count_bits</a>(mp_int z);
+mp_size <a href="imath.h#L368">mp_int_count_bits</a>(mp_int z);
 </pre>
  -  Returns the number of significant bits in `z`.
 
@@ -592,7 +592,7 @@ mp_result <a href="imath.h#L388">mp_int_read_binary</a>(mp_int z, unsigned char 
 
 ------------
 <a id="mp_int_binary_len"></a><pre>
-mp_result <a href="imath.h#L391">mp_int_binary_len</a>(mp_int z);
+mp_size <a href="imath.h#L391">mp_int_binary_len</a>(mp_int z);
 </pre>
  -  Returns the number of bytes to represent `z` in 2's complement binary.
 
@@ -620,7 +620,7 @@ mp_result <a href="imath.h#L407">mp_int_read_unsigned</a>(mp_int z, unsigned cha
 
 ------------
 <a id="mp_int_unsigned_len"></a><pre>
-mp_result <a href="imath.h#L411">mp_int_unsigned_len</a>(mp_int z);
+mp_size <a href="imath.h#L411">mp_int_unsigned_len</a>(mp_int z);
 </pre>
  -  Returns the number of bytes required to represent `z` as an unsigned binary
     value in base 256.
@@ -939,7 +939,7 @@ mp_result <a href="imrat.h#L220">mp_rat_to_decimal</a>(mp_rat r, mp_size radix, 
 
 ------------
 <a id="mp_rat_string_len"></a><pre>
-mp_result <a href="imrat.h#L226">mp_rat_string_len</a>(mp_rat r, mp_size radix);
+mp_size <a href="imrat.h#L226">mp_rat_string_len</a>(mp_rat r, mp_size radix);
 </pre>
  -  Reports the minimum number of characters required to represent `r` as a
     zero-terminated string in the given `radix`.
@@ -947,7 +947,7 @@ mp_result <a href="imrat.h#L226">mp_rat_string_len</a>(mp_rat r, mp_size radix);
 
 ------------
 <a id="mp_rat_decimal_len"></a><pre>
-mp_result <a href="imrat.h#L231">mp_rat_decimal_len</a>(mp_rat r, mp_size radix, mp_size prec);
+mp_size <a href="imrat.h#L231">mp_rat_decimal_len</a>(mp_rat r, mp_size radix, mp_size prec);
 </pre>
  -  Reports the length in bytes of the buffer needed to convert `r` using the
     `mp_rat_to_decimal()` function with the specified `radix` and `prec`. The

--- a/imath.c
+++ b/imath.c
@@ -1489,7 +1489,7 @@ mp_result mp_int_to_string(mp_int z, mp_size radix, char* str, int limit) {
   }
 }
 
-mp_result mp_int_string_len(mp_int z, mp_size radix) {
+mp_size mp_int_string_len(mp_int z, mp_size radix) {
   assert(z != NULL);
   assert(radix >= MP_MIN_RADIX && radix <= MP_MAX_RADIX);
 
@@ -1559,7 +1559,7 @@ mp_result mp_int_read_cstring(mp_int z, mp_size radix, const char* str,
   }
 }
 
-mp_result mp_int_count_bits(mp_int z) {
+mp_size mp_int_count_bits(mp_int z) {
   assert(z != NULL);
 
   mp_size uz = MP_USED(z);
@@ -1619,11 +1619,11 @@ mp_result mp_int_read_binary(mp_int z, unsigned char* buf, int len) {
   return MP_OK;
 }
 
-mp_result mp_int_binary_len(mp_int z) {
-  mp_result res = mp_int_count_bits(z);
-  if (res <= 0) return res;
+mp_size mp_int_binary_len(mp_int z) {
+  mp_size res = mp_int_count_bits(z);
+  if (res == 0) return res;
 
-  int bytes = mp_int_unsigned_len(z);
+  mp_size bytes = mp_int_unsigned_len(z);
 
   /* If the highest-order bit falls exactly on a byte boundary, we need to pad
      with an extra byte so that the sign will be read correctly when reading it
@@ -1659,11 +1659,9 @@ mp_result mp_int_read_unsigned(mp_int z, unsigned char* buf, int len) {
   return MP_OK;
 }
 
-mp_result mp_int_unsigned_len(mp_int z) {
-  mp_result res = mp_int_count_bits(z);
-  if (res <= 0) return res;
-
-  int bytes = (res + (CHAR_BIT - 1)) / CHAR_BIT;
+mp_size mp_int_unsigned_len(mp_int z) {
+  mp_size res = mp_int_count_bits(z);
+  mp_size bytes = (res + (CHAR_BIT - 1)) / CHAR_BIT;
   return bytes;
 }
 

--- a/imath.h
+++ b/imath.h
@@ -329,7 +329,7 @@ mp_result mp_int_to_string(mp_int z, mp_size radix, char *str, int limit);
 /** Reports the minimum number of characters required to represent `z` as a
     zero-terminated string in the given `radix`.
     Requires `MP_MIN_RADIX <= radix <= MP_MAX_RADIX`. */
-mp_result mp_int_string_len(mp_int z, mp_size radix);
+mp_size mp_int_string_len(mp_int z, mp_size radix);
 
 /** Reads a string of ASCII digits in the specified `radix` from the zero
     terminated `str` provided into `z`. For values of `radix > 10`, the letters
@@ -365,7 +365,7 @@ mp_result mp_int_read_string(mp_int z, mp_size radix, const char *str);
 mp_result mp_int_read_cstring(mp_int z, mp_size radix, const char *str, char **end);
 
 /** Returns the number of significant bits in `z`. */
-mp_result mp_int_count_bits(mp_int z);
+mp_size mp_int_count_bits(mp_int z);
 
 /** Converts `z` to 2's complement binary, writing at most `limit` bytes into
     the given `buf`.  Returns `MP_TRUNC` if the buffer limit was too small to
@@ -388,7 +388,7 @@ mp_result mp_int_to_binary(mp_int z, unsigned char *buf, int limit);
 mp_result mp_int_read_binary(mp_int z, unsigned char *buf, int len);
 
 /** Returns the number of bytes to represent `z` in 2's complement binary. */
-mp_result mp_int_binary_len(mp_int z);
+mp_size mp_int_binary_len(mp_int z);
 
 /** Converts the magnitude of `z` to unsigned binary, writing at most `limit`
     bytes into the given `buf`.  The sign of `z` is ignored, but `z` is not
@@ -408,7 +408,7 @@ mp_result mp_int_read_unsigned(mp_int z, unsigned char *buf, int len);
 
 /** Returns the number of bytes required to represent `z` as an unsigned binary
     value in base 256. */
-mp_result mp_int_unsigned_len(mp_int z);
+mp_size mp_int_unsigned_len(mp_int z);
 
 /** Returns a pointer to a brief, human-readable, zero-terminated string
     describing `res`. The returned string is statically allocated and must not

--- a/imrat.c
+++ b/imrat.c
@@ -643,9 +643,9 @@ CLEANUP:
   return res;
 }
 
-mp_result mp_rat_string_len(mp_rat r, mp_size radix) {
-  mp_result d_len = 0;
-  mp_result n_len = mp_int_string_len(MP_NUMER_P(r), radix);
+mp_size mp_rat_string_len(mp_rat r, mp_size radix) {
+  mp_size d_len = 0;
+  mp_size n_len = mp_int_string_len(MP_NUMER_P(r), radix);
 
   if (mp_int_compare_zero(MP_NUMER_P(r)) != 0) {
     d_len = mp_int_string_len(MP_DENOM_P(r), radix);
@@ -659,7 +659,7 @@ mp_result mp_rat_string_len(mp_rat r, mp_size radix) {
   return n_len + d_len;
 }
 
-mp_result mp_rat_decimal_len(mp_rat r, mp_size radix, mp_size prec) {
+mp_size mp_rat_decimal_len(mp_rat r, mp_size radix, mp_size prec) {
   int f_len;
   int z_len = mp_int_string_len(MP_NUMER_P(r), radix);
 

--- a/imrat.h
+++ b/imrat.h
@@ -223,12 +223,12 @@ mp_result mp_rat_to_decimal(mp_rat r, mp_size radix, mp_size prec,
 /** Reports the minimum number of characters required to represent `r` as a
     zero-terminated string in the given `radix`.
     Requires `MP_MIN_RADIX <= radix <= MP_MAX_RADIX`. */
-mp_result mp_rat_string_len(mp_rat r, mp_size radix);
+mp_size mp_rat_string_len(mp_rat r, mp_size radix);
 
 /** Reports the length in bytes of the buffer needed to convert `r` using the
     `mp_rat_to_decimal()` function with the specified `radix` and `prec`. The
     buffer size estimate may slightly exceed the actual required capacity. */
-mp_result mp_rat_decimal_len(mp_rat r, mp_size radix, mp_size prec);
+mp_size mp_rat_decimal_len(mp_rat r, mp_size radix, mp_size prec);
 
 /** Sets `r` to the value represented by a zero-terminated string `str` in the
     format `"n/d"` including a sign flag. It returns `MP_UNDEF` if the encoded


### PR DESCRIPTION
I originally designed the API to use mp_result both for error results and for
"small" result values. However, there are several functions that do not require
error status, and could properly use mp_size instead.

Updates #72
